### PR TITLE
Fix lost draconian having 2 hp less than intended

### DIFF
--- a/src/main/resources/data/origins-plus-plus/powers/lost-draconian/weakened.json
+++ b/src/main/resources/data/origins-plus-plus/powers/lost-draconian/weakened.json
@@ -3,7 +3,7 @@
   "modifier": {
     "name": "Fragile health reduction",
     "attribute": "minecraft:generic.max_health",
-    "value": -6.0,
+    "value": -4.0,
     "operation": "addition"
   },
   "hidden": false,


### PR DESCRIPTION
* Lost Draconian had 3 hearts less while description claims that it should lose 2 hearts