### PR TITLE
added more items to the `sweet_foods` tags from various delight mods

### DIFF
--- a/data/origins-plus-plus-modded-support/tags/items/sweet_foods.json
+++ b/data/origins-plus-plus-modded-support/tags/items/sweet_foods.json
@@ -1,11 +1,11 @@
 {
   "values":[
     {
-      "id":"#c:sweeteners",
+      "id":"#c:fruits",
       "required":false
     },
     {
-      "id":"#c:fruits",
+      "id":"#c:sweeteners",
       "required":false
     },
     {
@@ -13,11 +13,7 @@
       "required":false
     },
     {
-      "id":"archon:mana_berries",
-      "required":false
-    },
-    {
-      "id":"adorn:sweet_berry_juice",
+      "id":"adorn:glow_berry_tea",
       "required":false
     },
     {
@@ -25,19 +21,75 @@
       "required":false
     },
     {
-      "id":"adorn:glow_berry_tea",
+      "id":"adorn:sweet_berry_juice",
       "required":false
     },
     {
-      "id":"betterend:cave_pumpkin_pie",
+      "id":"alexcaves:green_soylent",
       "required":false
     },
     {
-      "id":"betterend:sweet_berry_jelly",
+      "id":"alexcaves:spelunkie",
       "required":false
     },
     {
-      "id":"betterend:shadow_berry_jelly",
+      "id":"alexscavesdelight:acid_juice",
+      "required":false
+    },
+    {
+      "id":"alexscavesdelight:bioluminesscence_jem",
+      "required":false
+    },
+    {
+      "id":"alexscavesdelight:bioluminesscence_pie",
+      "required":false
+    },
+    {
+      "id":"alexscavesdelight:magma_jem",
+      "required":false
+    },
+    {
+      "id":"aquaculturedelight:jellyfish_jelly",
+      "required":false
+    },
+    {
+      "id":"aquamirae:sea_casserole",
+      "required":false
+    },
+    {
+      "id":"archon:mana_berries",
+      "required":false
+    },
+    {
+      "id":"ars_nouceau:source_berry_pie",
+      "required":false
+    },
+    {
+      "id":"ars_nouceau:source_berry_roll",
+      "required":false
+    },
+    {
+      "id":"ars_nouveau:bastion_pod",
+      "required":false
+    },
+    {
+      "id":"ars_nouveau:bombegranate_pod",
+      "required":false
+    },
+    {
+      "id":"ars_nouveau:frostaya_pod",
+      "required":false
+    },
+    {
+      "id":"ars_nouveau:mendosteen_pod",
+      "required":false
+    },
+    {
+      "id":"ars_nouveau:source_berry_pie",
+      "required":false
+    },
+    {
+      "id":"betterend:blossom_berry",
       "required":false
     },
     {
@@ -45,7 +97,7 @@
       "required":false
     },
     {
-      "id":"betterend:shadow_berry_raw",
+      "id":"betterend:cave_pumpkin_pie",
       "required":false
     },
     {
@@ -53,7 +105,15 @@
       "required":false
     },
     {
-      "id":"betterend:blossom_berry",
+      "id":"betterend:shadow_berry_jelly",
+      "required":false
+    },
+    {
+      "id":"betterend:shadow_berry_raw",
+      "required":false
+    },
+    {
+      "id":"betterend:sweet_berry_jelly",
       "required":false
     },
     {
@@ -73,11 +133,11 @@
       "required":false
     },
     {
-      "id":"bosses_of_mass_destruction:crystal_fruit",
+      "id":"biomancy:bloomberry",
       "required":false
     },
     {
-      "id":"brewinandchewin:saccharine_rum",
+      "id":"bosses_of_mass_destruction:crystal_fruit",
       "required":false
     },
     {
@@ -85,19 +145,11 @@
       "required":false
     },
     {
+      "id":"brewinandchewin:saccharine_rum",
+      "required":false
+    },
+    {
       "id":"bwplus:dragonfruit",
-      "required":false
-    },
-    {
-      "id":"byg:nightshade_berries",
-      "required":false
-    },
-    {
-      "id":"byg:crimson_berries",
-      "required":false
-    },
-    {
-      "id":"byg:blueberries",
       "required":false
     },
     {
@@ -105,11 +157,7 @@
       "required":false
     },
     {
-      "id":"byg:joshua_fruit",
-      "required":false
-    },
-    {
-      "id":"byg:green_apple",
+      "id":"byg:blueberries",
       "required":false
     },
     {
@@ -117,11 +165,7 @@
       "required":false
     },
     {
-      "id":"byg:green_apple_pie",
-      "required":false
-    },
-    {
-      "id":"byg:nightshade_berry_pie",
+      "id":"byg:crimson_berries",
       "required":false
     },
     {
@@ -129,11 +173,343 @@
       "required":false
     },
     {
+      "id":"byg:green_apple",
+      "required":false
+    },
+    {
+      "id":"byg:green_apple_pie",
+      "required":false
+    },
+    {
+      "id":"byg:joshua_fruit",
+      "required":false
+    },
+    {
+      "id":"byg:nightshade_berries",
+      "required":false
+    },
+    {
+      "id":"byg:nightshade_berry_pie",
+      "required":false
+    },
+    {
       "id":"cinderscapes:bramble_berries",
       "required":false
     },
     {
+      "id":"croptopia:apple_juice",
+      "required":false
+    },
+    {
+      "id":"croptopia:apple_pie",
+      "required":false
+    },
+    {
+      "id":"croptopia:apricot_jam",
+      "required":false
+    },
+    {
+      "id":"croptopia:banana_cream_pie",
+      "required":false
+    },
+    {
+      "id":"croptopia:banana_nut_bread",
+      "required":false
+    },
+    {
+      "id":"croptopia:banana_smoothie",
+      "required":false
+    },
+    {
+      "id":"croptopia:blackberry_jam",
+      "required":false
+    },
+    {
+      "id":"croptopia:blueberry_jam",
+      "required":false
+    },
+    {
+      "id":"croptopia:brownies",
+      "required":false
+    },
+    {
+      "id":"croptopia:candy_corn",
+      "required":false
+    },
+    {
+      "id":"croptopia:cheese_cake",
+      "required":false
+    },
+    {
+      "id":"croptopia:cherry_jam",
+      "required":false
+    },
+    {
+      "id":"croptopia:cherry_pie",
+      "required":false
+    },
+    {
+      "id":"croptopia:chocolate",
+      "required":false
+    },
+    {
+      "id":"croptopia:chocolate_ice_cream",
+      "required":false
+    },
+    {
+      "id":"croptopia:chocolate_milkshake",
+      "required":false
+    },
+    {
+      "id":"croptopia:churros",
+      "required":false
+    },
+    {
+      "id":"croptopia:cranberry_juice",
+      "required":false
+    },
+    {
       "id":"croptopia:doughnut",
+      "required":false
+    },
+    {
+      "id":"croptopia:elderberry_jam",
+      "required":false
+    },
+    {
+      "id":"croptopia:eton_mess",
+      "required":false
+    },
+    {
+      "id":"croptopia:figgy_pudding",
+      "required":false
+    },
+    {
+      "id":"croptopia:fruit_cake",
+      "required":false
+    },
+    {
+      "id":"croptopia:fruit_smoothie",
+      "required":false
+    },
+    {
+      "id":"croptopia:grape_jam",
+      "required":false
+    },
+    {
+      "id":"croptopia:grape_juice",
+      "required":false
+    },
+    {
+      "id":"croptopia:horchata",
+      "required":false
+    },
+    {
+      "id":"croptopia:kale_smoothie",
+      "required":false
+    },
+    {
+      "id":"croptopia:kiwi_sorbet",
+      "required":false
+    },
+    {
+      "id":"croptopia:lemon_coconut_bar",
+      "required":false
+    },
+    {
+      "id":"croptopia:lemonade",
+      "required":false
+    },
+    {
+      "id":"croptopia:limeade",
+      "required":false
+    },
+    {
+      "id":"croptopia:mango_ice_cream",
+      "required":false
+    },
+    {
+      "id":"croptopia:melon_juice",
+      "required":false
+    },
+    {
+      "id":"croptopia:orange_juice",
+      "required":false
+    },
+    {
+      "id":"croptopia:peach_jam",
+      "required":false
+    },
+    {
+      "id":"croptopia:pineapple_juice",
+      "required":false
+    },
+    {
+      "id":"croptopia:pumpkin_spice_latte",
+      "required":false
+    },
+    {
+      "id":"croptopia:raspberry_jam",
+      "required":false
+    },
+    {
+      "id":"croptopia:rhubarb_crisp",
+      "required":false
+    },
+    {
+      "id":"croptopia:rum_raisin_ice_cream",
+      "required":false
+    },
+    {
+      "id":"croptopia:saguaro_juice",
+      "required":false
+    },
+    {
+      "id":"croptopia:scones",
+      "required":false
+    },
+    {
+      "id":"croptopia:snicker_doodle",
+      "required":false
+    },
+    {
+      "id":"croptopia:sticky_toffee_pudding",
+      "required":false
+    },
+    {
+      "id":"croptopia:strawberry_ice_cream",
+      "required":false
+    },
+    {
+      "id":"croptopia:strawberry_jam",
+      "required":false
+    },
+    {
+      "id":"croptopia:strawberry_smoothie",
+      "required":false
+    },
+    {
+      "id":"croptopia:treacle_tart",
+      "required":false
+    },
+    {
+      "id":"croptopia:tres_leche_cake",
+      "required":false
+    },
+    {
+      "id":"croptopia:trifle",
+      "required":false
+    },
+    {
+      "id":"croptopia:vanilla_ice_cream",
+      "required":false
+    },
+    {
+      "id":"croptopia:yam_jam",
+      "required":false
+    },
+    {
+      "id":"delightful:berry_matcha_latte",
+      "required":false
+    },
+    {
+      "id":"delightful:cantaloupe_bread",
+      "required":false
+    },
+    {
+      "id":"delightful:cantaloupe_gummy",
+      "required":false
+    },
+    {
+      "id":"delightful:cantaloupe_popsicle",
+      "required":false
+    },
+    {
+      "id":"delightful:cantaloupe_slice",
+      "required":false
+    },
+    {
+      "id":"delightful:cooked_marshmallow_stick",
+      "required":false
+    },
+    {
+      "id":"delightful:ender_nectar",
+      "required":false
+    },
+    {
+      "id":"delightful:glow_jelly_bottle",
+      "required":false
+    },
+    {
+      "id":"delightful:jelly_bottle",
+      "required":false
+    },
+    {
+      "id":"delightful:marshmallow_stick",
+      "required":false
+    },
+    {
+      "id":"delightful:matcha_gummy",
+      "required":false
+    },
+    {
+      "id":"delightful:matcha_ice_cream",
+      "required":false
+    },
+    {
+      "id":"delightful:matcha_latte",
+      "required":false
+    },
+    {
+      "id":"delightful:matcha_milkshake",
+      "required":false
+    },
+    {
+      "id":"delightful:nut_butter_and_jelly_sandwich",
+      "required":false
+    },
+    {
+      "id":"delightful:nut_butter_bottle",
+      "required":false
+    },
+    {
+      "id":"delightful:pumpkin_pie_slice",
+      "required":false
+    },
+    {
+      "id":"delightful:salmonberries",
+      "required":false
+    },
+    {
+      "id":"delightful:salmonberry_gummy",
+      "required":false
+    },
+    {
+      "id":"delightful:salmonberry_ice_cream",
+      "required":false
+    },
+    {
+      "id":"delightful:salmonberry_milkshake",
+      "required":false
+    },
+    {
+      "id":"delightful:salmonberry_pie",
+      "required":false
+    },
+    {
+      "id":"delightful:salmonberry_pie_slice",
+      "required":false
+    },
+    {
+      "id":"delightful:smore",
+      "required":false
+    },
+    {
+      "id":"delightful:source_berry_pie_slice",
+      "required":false
+    },
+    {
+      "id":"delightful:wrapped_cantaloupe",
       "required":false
     },
     {
@@ -145,75 +521,19 @@
       "required":false
     },
     {
-      "id":"expandeddelight:sweet_potato",
+      "id":"endersdelight:chorus_pie",
       "required":false
     },
     {
-      "id":"expandeddelight:cinnamon_rice",
+      "id":"endersdelight:chorus_pie_slice",
       "required":false
     },
     {
-      "id":"expandeddelight:cinnamon_apples",
+      "id":"endersdelight:strange_eclair",
       "required":false
     },
     {
-      "id":"expandeddelight:baked_sweet_potato",
-      "required":false
-    },
-    {
-      "id":"expandeddelight:peanut_butter_honey_sandwich",
-      "required":false
-    },
-    {
-      "id":"expandeddelight:chocolate_cookie",
-      "required":false
-    },
-    {
-      "id":"expandeddelight:sugar_cookie",
-      "required":false
-    },
-    {
-      "id":"expandeddelight:snickerdoodle",
-      "required":false
-    },
-    {
-      "id":"expandeddelight:sweet_berry_jelly_sandwich",
-      "required":false
-    },
-    {
-      "id":"expandeddelight:glow_berry_jelly_sandwich",
-      "required":false
-    },
-    {
-      "id":"expandeddelight:sweet_berry_juice",
-      "required":false
-    },
-    {
-      "id":"expandeddelight:glow_berry_juice",
-      "required":false
-    },
-    {
-      "id":"expandeddelight:sweet_berry_jelly",
-      "required":false
-    },
-    {
-      "id":"expandeddelight:glow_berry_jelly",
-      "required":false
-    },
-    {
-      "id":"expandeddelight:honey_peanut_soup",
-      "required":false
-    },
-    {
-      "id":"expandeddelight:sweet_roll",
-      "required":false
-    },
-    {
-      "id":"expandeddelight:berry_sweet_roll",
-      "required":false
-    },
-    {
-      "id":"expandeddelight:glow_berry_sweet_roll",
+      "id":"endersdelight:uncanny_cookies",
       "required":false
     },
     {
@@ -221,31 +541,99 @@
       "required":false
     },
     {
-      "id":"farmersdelight:sweet_berry_cookie",
+      "id":"expandeddelight:baked_sweet_potato",
       "required":false
     },
     {
-      "id":"farmersdelight:cake_slice",
+      "id":"expandeddelight:berry_sweet_roll",
       "required":false
     },
     {
-      "id":"farmersdelight:coffee_cake_slice",
+      "id":"expandeddelight:chocolate_cookie",
       "required":false
     },
     {
-      "id":"farmersdelight:honey_cookie",
+      "id":"expandeddelight:cinnamon_apples",
       "required":false
     },
     {
-      "id":"farmersdelight:fruit_salad",
+      "id":"expandeddelight:cinnamon_rice",
       "required":false
     },
     {
-      "id":"farmersdelight:sweet_berry_cheesecake_slice",
+      "id":"expandeddelight:glow_berry_jelly",
       "required":false
     },
     {
-      "id":"farmersdelight:chocolate_pie_slice",
+      "id":"expandeddelight:glow_berry_jelly_sandwich",
+      "required":false
+    },
+    {
+      "id":"expandeddelight:glow_berry_juice",
+      "required":false
+    },
+    {
+      "id":"expandeddelight:glow_berry_sweet_roll",
+      "required":false
+    },
+    {
+      "id":"expandeddelight:honey_peanut_soup",
+      "required":false
+    },
+    {
+      "id":"expandeddelight:peanut_butter_honey_sandwich",
+      "required":false
+    },
+    {
+      "id":"expandeddelight:snickerdoodle",
+      "required":false
+    },
+    {
+      "id":"expandeddelight:sugar_cookie",
+      "required":false
+    },
+    {
+      "id":"expandeddelight:sweet_berry_jelly",
+      "required":false
+    },
+    {
+      "id":"expandeddelight:sweet_berry_jelly_sandwich",
+      "required":false
+    },
+    {
+      "id":"expandeddelight:sweet_berry_juice",
+      "required":false
+    },
+    {
+      "id":"expandeddelight:sweet_potato",
+      "required":false
+    },
+    {
+      "id":"expandeddelight:sweet_roll",
+      "required":false
+    },
+    {
+      "id":"farmerdelight:glow_berry_custard",
+      "required":false
+    },
+    {
+      "id":"farmerdelight:honey_glazed_ham",
+      "required":false
+    },
+    {
+      "id":"farmerdelight:honey_glazed_ham_block",
+      "required":false
+    },
+    {
+      "id":"farmerdelight:hot_cocoa",
+      "required":false
+    },
+    {
+      "id":"farmersdelight:apple_cider",
+      "required":false
+    },
+    {
+      "id":"farmersdelight:apple_pie",
       "required":false
     },
     {
@@ -253,23 +641,51 @@
       "required":false
     },
     {
+      "id":"farmersdelight:cake_slice",
+      "required":false
+    },
+    {
+      "id":"farmersdelight:chocolate_pie",
+      "required":false
+    },
+    {
+      "id":"farmersdelight:chocolate_pie_slice",
+      "required":false
+    },
+    {
+      "id":"farmersdelight:coffee_cake_slice",
+      "required":false
+    },
+    {
+      "id":"farmersdelight:fruit_salad",
+      "required":false
+    },
+    {
+      "id":"farmersdelight:honey_cookie",
+      "required":false
+    },
+    {
+      "id":"farmersdelight:melon_juice",
+      "required":false
+    },
+    {
+      "id":"farmersdelight:melon_popsicle",
+      "required":false
+    },
+    {
       "id":"farmersdelight:pie_crust",
       "required":false
     },
     {
-      "id":"farmersrespite:coffee_berries",
+      "id":"farmersdelight:sweet_berry_cheesecake",
       "required":false
     },
     {
-      "id":"farmersrespite:rose_hip_tea",
+      "id":"farmersdelight:sweet_berry_cheesecake_slice",
       "required":false
     },
     {
-      "id":"farmersrespite:honey_cookie",
-      "required":false
-    },
-    {
-      "id":"farmersrespite:dandelion_tea",
+      "id":"farmersdelight:sweet_berry_cookie",
       "required":false
     },
     {
@@ -277,11 +693,11 @@
       "required":false
     },
     {
-      "id":"farmersrespite:long_apple_cider",
+      "id":"farmersrespite:coffee_berries",
       "required":false
     },
     {
-      "id":"farmersrespite:strong_apple_cider",
+      "id":"farmersrespite:dandelion_tea",
       "required":false
     },
     {
@@ -289,11 +705,19 @@
       "required":false
     },
     {
-      "id":"galosphere_delight:spectral_soda",
+      "id":"farmersrespite:honey_cookie",
       "required":false
     },
     {
-      "id":"galosphere_delight:lumiere_shimmer_drink",
+      "id":"farmersrespite:long_apple_cider",
+      "required":false
+    },
+    {
+      "id":"farmersrespite:rose_hip_tea",
+      "required":false
+    },
+    {
+      "id":"farmersrespite:strong_apple_cider",
       "required":false
     },
     {
@@ -301,11 +725,15 @@
       "required":false
     },
     {
-      "id":"immersive_weathering:pond_water",
+      "id":"galosphere_delight:lumiere_shimmer_drink",
       "required":false
     },
     {
-      "id":"meadow:jug_juniper_tea",
+      "id":"galosphere_delight:spectral_soda",
+      "required":false
+    },
+    {
+      "id":"immersive_weathering:pond_water",
       "required":false
     },
     {
@@ -313,23 +741,11 @@
       "required":false
     },
     {
+      "id":"meadow:jug_juniper_tea",
+      "required":false
+    },
+    {
       "id":"miners_delight:hot_cocoa_cup",
-      "required":false
-    },
-    {
-      "id":"mythicupgrades:sapphire_apple",
-      "required":false
-    },
-    {
-      "id":"mythicupgrades:ruby_apple",
-      "required":false
-    },
-    {
-      "id":"mythicupgrades:jade_apple",
-      "required":false
-    },
-    {
-      "id":"mythicupgrades:topaz_apple",
       "required":false
     },
     {
@@ -337,7 +753,47 @@
       "required":false
     },
     {
+      "id":"mythicupgrades:jade_apple",
+      "required":false
+    },
+    {
+      "id":"mythicupgrades:ruby_apple",
+      "required":false
+    },
+    {
+      "id":"mythicupgrades:sapphire_apple",
+      "required":false
+    },
+    {
+      "id":"mythicupgrades:topaz_apple",
+      "required":false
+    },
+    {
+      "id":"nethersdelight:magma_gelatin",
+      "required":false
+    },
+    {
+      "id":"nethersdelight:nether_skewer",
+      "required":false
+    },
+    {
+      "id":"nethersdelight:propelpearl",
+      "required":false
+    },
+    {
+      "id":"paradise_lost:amadrys_bread_glazed",
+      "required":false
+    },
+    {
       "id":"paradise_lost:blue_berry",
+      "required":false
+    },
+    {
+      "id":"paradise_lost:blue_gummy_swet",
+      "required":false
+    },
+    {
+      "id":"paradise_lost:candy_cane",
       "required":false
     },
     {
@@ -349,15 +805,23 @@
       "required":false
     },
     {
-      "id":"paradise_lost:candy_cane",
+      "id":"quark:ancient_fruit",
       "required":false
     },
     {
-      "id":"paradise_lost:blue_gummy_swet",
+      "id":"refurbished_furniture:glow_berry_jam",
       "required":false
     },
     {
-      "id":"paradise_lost:amadrys_bread_glazed",
+      "id":"refurbished_furniture:glow_berry_jam_toast",
+      "required":false
+    },
+    {
+      "id":"refurbished_furniture:sweet_berry_jam",
+      "required":false
+    },
+    {
+      "id":"refurbished_furniture:sweet_berry_jam_toast",
       "required":false
     },
     {
@@ -377,7 +841,7 @@
       "required":false
     },
     {
-      "id":"the_bumblezone:sugar_water_bottle",
+      "id":"supplementaries:pancake",
       "required":false
     },
     {
@@ -385,11 +849,75 @@
       "required":false
     },
     {
+      "id":"the_bumblezone:honey_crystal_shards",
+      "required":false
+    },
+    {
       "id":"the_bumblezone:royal_jelly_bottle",
       "required":false
     },
     {
-      "id":"the_bumblezone:honey_crystal_shards",
+      "id":"the_bumblezone:sugar_water_bottle",
+      "required":false
+    },
+    {
+      "id":"twilightdelight:aurora_pie",
+      "required":false
+    },
+    {
+      "id":"twilightdelight:aurora_pie_slice",
+      "required":false
+    },
+    {
+      "id":"twilightdelight:berry_stick",
+      "required":false
+    },
+    {
+      "id":"twilightdelight:chocolate_113",
+      "required":false
+    },
+    {
+      "id":"twilightdelight:chocolate_wafer",
+      "required":false
+    },
+    {
+      "id":"twilightdelight:glacier_ice_tea",
+      "required":false
+    },
+    {
+      "id":"twilightdelight:glowstew",
+      "required":false
+    },
+    {
+      "id":"twilightdelight:honey_113",
+      "required":false
+    },
+    {
+      "id":"twilightdelight:milky_113",
+      "required":false
+    },
+    {
+      "id":"twilightdelight:phytochemical_juice",
+      "required":false
+    },
+    {
+      "id":"twilightdelight:thorn_rose_tea",
+      "required":false
+    },
+    {
+      "id":"twilightdelight:torchberry_cookie",
+      "required":false
+    },
+    {
+      "id":"twilightdelight:torchberry_juice",
+      "required":false
+    },
+    {
+      "id":"twilightdelight:torchberry_pie",
+      "required":false
+    },
+    {
+      "id":"twilightdelight:torchberry_pie_slice",
       "required":false
     },
     {
@@ -401,47 +929,7 @@
       "required":false
     },
     {
-      "id":"vinery:apple_cupcake",
-      "required":false
-    },
-    {
-      "id":"vinery:chocolate_bread",
-      "required":false
-    },
-    {
-      "id":"vinery:apple_pie_slice",
-      "required":false
-    },
-    {
-      "id":"vinery:apple_juice",
-      "required":false
-    },
-    {
-      "id":"vinery:chenet_wine",
-      "required":false
-    },
-    {
-      "id":"vinery:king_danis_wine",
-      "required":false
-    },
-    {
-      "id":"vinery:noir_wine",
-      "required":false
-    },
-    {
-      "id":"vinery:clark_wine",
-      "required":false
-    },
-    {
-      "id":"vinery:mellohi_wine",
-      "required":false
-    },
-    {
-      "id":"vinery:bolvar_wine",
-      "required":false
-    },
-    {
-      "id":"vinery:cherry_wine",
+      "id":"vinery:aegis_wine",
       "required":false
     },
     {
@@ -449,19 +937,19 @@
       "required":false
     },
     {
-      "id":"vinery:kelp_cider",
+      "id":"vinery:apple_cupcake",
       "required":false
     },
     {
-      "id":"vinery:solaris_wine",
+      "id":"vinery:apple_juice",
       "required":false
     },
     {
-      "id":"vinery:jellie_wine",
+      "id":"vinery:apple_mash",
       "required":false
     },
     {
-      "id":"vinery:aegis_wine",
+      "id":"vinery:apple_pie_slice",
       "required":false
     },
     {
@@ -469,7 +957,83 @@
       "required":false
     },
     {
-      "id":"winterly:red_candy_cane",
+      "id":"vinery:bolvar_wine",
+      "required":false
+    },
+    {
+      "id":"vinery:chenet_wine",
+      "required":false
+    },
+    {
+      "id":"vinery:cherry",
+      "required":false
+    },
+    {
+      "id":"vinery:cherry_wine",
+      "required":false
+    },
+    {
+      "id":"vinery:chocolate_bread",
+      "required":false
+    },
+    {
+      "id":"vinery:clark_wine",
+      "required":false
+    },
+    {
+      "id":"vinery:jellie_wine",
+      "required":false
+    },
+    {
+      "id":"vinery:jungle_grapes_red",
+      "required":false
+    },
+    {
+      "id":"vinery:jungle_grapes_white",
+      "required":false
+    },
+    {
+      "id":"vinery:kelp_cider",
+      "required":false
+    },
+    {
+      "id":"vinery:king_danis_wine",
+      "required":false
+    },
+    {
+      "id":"vinery:mellohi_wine",
+      "required":false
+    },
+    {
+      "id":"vinery:noir_wine",
+      "required":false
+    },
+    {
+      "id":"vinery:red_grape",
+      "required":false
+    },
+    {
+      "id":"vinery:savanna_grapes_red",
+      "required":false
+    },
+    {
+      "id":"vinery:savanna_grapes_white",
+      "required":false
+    },
+    {
+      "id":"vinery:solaris_wine",
+      "required":false
+    },
+    {
+      "id":"vinery:taiga_grapes_red",
+      "required":false
+    },
+    {
+      "id":"vinery:taiga_grapes_white",
+      "required":false
+    },
+    {
+      "id":"vinery:white_grape",
       "required":false
     },
     {
@@ -481,7 +1045,7 @@
       "required":false
     },
     {
-      "id":"xps:xp_berries",
+      "id":"winterly:red_candy_cane",
       "required":false
     },
     {
@@ -489,211 +1053,7 @@
       "required":false
     },
     {
-      "id":"croptopia:chocolate",
-      "required":false
-    },
-    {
-      "id":"croptopia:grape_juice",
-      "required":false
-    },
-    {
-      "id":"croptopia:orange_juice",
-      "required":false
-    },
-    {
-      "id":"croptopia:apple_juice",
-      "required":false
-    },
-    {
-      "id":"croptopia:cranberry_juice",
-      "required":false
-    },
-    {
-      "id":"croptopia:saguaro_juice",
-      "required":false
-    },
-    {
-      "id":"croptopia:melon_juice",
-      "required":false
-    },
-    {
-      "id":"croptopia:pineapple_juice",
-      "required":false
-    },
-    {
-      "id":"croptopia:lemonade",
-      "required":false
-    },
-    {
-      "id":"croptopia:limeade",
-      "required":false
-    },
-    {
-      "id":"croptopia:strawberry_smoothie",
-      "required":false
-    },
-    {
-      "id":"croptopia:banana_smoothie",
-      "required":false
-    },
-    {
-      "id":"croptopia:kale_smoothie",
-      "required":false
-    },
-    {
-      "id":"croptopia:fruit_smoothie",
-      "required":false
-    },
-    {
-      "id":"croptopia:chocolate_milkshake",
-      "required":false
-    },
-    {
-      "id":"croptopia:pumpkin_spice_latte",
-      "required":false
-    },
-    {
-      "id":"croptopia:grape_jam",
-      "required":false
-    },
-    {
-      "id":"croptopia:strawberry_jam",
-      "required":false
-    },
-    {
-      "id":"croptopia:peach_jam",
-      "required":false
-    },
-    {
-      "id":"croptopia:apricot_jam",
-      "required":false
-    },
-    {
-      "id":"croptopia:blackberry_jam",
-      "required":false
-    },
-    {
-      "id":"croptopia:blueberry_jam",
-      "required":false
-    },
-    {
-      "id":"croptopia:cherry_jam",
-      "required":false
-    },
-    {
-      "id":"croptopia:elderberry_jam",
-      "required":false
-    },
-    {
-      "id":"croptopia:raspberry_jam",
-      "required":false
-    },
-    {
-      "id":"croptopia:apple_pie",
-      "required":false
-    },
-    {
-      "id":"croptopia:yam_jam",
-      "required":false
-    },
-    {
-      "id":"croptopia:banana_cream_pie",
-      "required":false
-    },
-    {
-      "id":"croptopia:candy_corn",
-      "required":false
-    },
-    {
-      "id":"croptopia:vanilla_ice_cream",
-      "required":false
-    },
-    {
-      "id":"croptopia:strawberry_ice_cream",
-      "required":false
-    },
-    {
-      "id":"croptopia:mango_ice_cream",
-      "required":false
-    },
-    {
-      "id":"croptopia:rum_raisin_ice_cream",
-      "required":false
-    },
-    {
-      "id":"croptopia:cherry_pie",
-      "required":false
-    },
-    {
-      "id":"croptopia:cheese_cake",
-      "required":false
-    },
-    {
-      "id":"croptopia:brownies",
-      "required":false
-    },
-    {
-      "id":"croptopia:snicker_doodle",
-      "required":false
-    },
-    {
-      "id":"croptopia:banana_nut_bread",
-      "required":false
-    },
-    {
-      "id":"croptopia:horchata",
-      "required":false
-    },
-    {
-      "id":"croptopia:churros",
-      "required":false
-    },
-    {
-      "id":"croptopia:tres_leche_cake",
-      "required":false
-    },
-    {
-      "id":"croptopia:eton_mess",
-      "required":false
-    },
-    {
-      "id":"croptopia:scones",
-      "required":false
-    },
-    {
-      "id":"croptopia:figgy_pudding",
-      "required":false
-    },
-    {
-      "id":"croptopia:treacle_tart",
-      "required":false
-    },
-    {
-      "id":"croptopia:sticky_toffee_pudding",
-      "required":false
-    },
-    {
-      "id":"croptopia:trifle",
-      "required":false
-    },
-    {
-      "id":"croptopia:chocolate_ice_cream",
-      "required":false
-    },
-    {
-      "id":"croptopia:fruit_cake",
-      "required":false
-    },
-    {
-      "id":"croptopia:kiwi_sorbet",
-      "required":false
-    },
-    {
-      "id":"croptopia:lemon_coconut_bar",
-      "required":false
-    },
-    {
-      "id":"croptopia:rhubarb_crisp",
+      "id":"xps:xp_berries",
       "required":false
     }
   ]


### PR DESCRIPTION
I was playing the Marshmallow origin and wanted sweet foods to increase my sugar level; I noticed a bunch of modded foods weren't in the `sweet_foods` tags so I added some & alphabetized the list / got rid of duplicates.