### PR TITLE
make insect bearable

### DIFF
--- a/common/data/origins-plus-plus/functions/insect/size.mcfunction
+++ b/common/data/origins-plus-plus/functions/insect/size.mcfunction
@@ -1,3 +1,7 @@
+# scale the model without reducing reach, jump height, speed, etc.
 scale set pehkui:height 0.4
 scale set pehkui:width 0.4
+# scales dropped items. for some reason this isnt affected by either height or width.
+scale set pehkui:drops 0.4
+# scale persistance.
 scale persist set true

--- a/common/data/origins-plus-plus/functions/insect/size.mcfunction
+++ b/common/data/origins-plus-plus/functions/insect/size.mcfunction
@@ -1,3 +1,3 @@
-scale set pehkui:base 0.4
-scale set pehkui:reach 1.6
+scale set pehkui:height 0.4
+scale set pehkui:width 0.4
 scale persist set true


### PR DESCRIPTION
Base affects reach, speed, scale, step height, jump height and fall damage. The issues with base caused the speed power to *not* increase speed above that of a normal player as the origin description says.
This makes the scale only be affected. The reach scaling is made redundant by this, so it's removed.