### PR TITLE
wizard fix regen

### DIFF
--- a/common/data/origins-plus-plus/powers/wizard/magic.json
+++ b/common/data/origins-plus-plus/powers/wizard/magic.json
@@ -1,8 +1,10 @@
 {
 	"type":"origins:stacking_status_effect",
+	"loading_priority": 1,
 	"min_stacks":4,
 	"max_stacks":4,
-	"duration_per_stack":20,
+	"tick_rate": 25,
+	"duration_per_stack":250,
 	"effect":{
 		"effect":"minecraft:regeneration",
 		"show_particles":false,


### PR DESCRIPTION
fixes https://github.com/QuantumXenon/origins-plus-plus/issues/291
very weird issue and even weirder fix. from what i understand every time regeneration was being applied it reset the timer of the regen. for regen 1 every 25 ticks is half a heart so i just changed the timer to that. the second part of the fix, changing "duration_per_stack", i dont quite understand it myself i literally just had an instinct i had to make it a multiple of 25, and i went with 250 and it worked perfectly, make it make sense, cuz i cant